### PR TITLE
These changes do the following:

### DIFF
--- a/public/shopify-widget.js
+++ b/public/shopify-widget.js
@@ -1171,8 +1171,8 @@ console.log('Shopify try-on widget script started');
       const result = await addToCartResponse.json();
       console.log('Item added to cart:', result);
 
-      // Set a flag in localStorage to show a message after page reload
-      localStorage.setItem('showAddedMessage', 'true');
+      // Set a timestamp when the item is added
+      localStorage.setItem('itemAddedTimestamp', Date.now().toString());
 
       // Refresh the current page
       window.location.reload();
@@ -1183,21 +1183,24 @@ console.log('Shopify try-on widget script started');
     }
   }
 
-  // Function to update the "Add to Cart" button text
+  // Update the updateAddToCartButton function
   function updateAddToCartButton() {
     const addToCartButton = document.querySelector('.try-on-widget-add-to-cart-button');
-    if (addToCartButton && localStorage.getItem('showAddedMessage') === 'true') {
-      addToCartButton.textContent = 'Added!';
-      addToCartButton.disabled = true;
-      
-      setTimeout(() => {
-        addToCartButton.textContent = 'Add to Cart';
-        addToCartButton.disabled = false;
-        localStorage.removeItem('showAddedMessage');
-      }, 5000);
+    if (addToCartButton) {
+      const itemAddedTimestamp = localStorage.getItem('itemAddedTimestamp');
+      if (itemAddedTimestamp && Date.now() - parseInt(itemAddedTimestamp) < 5000) {
+        addToCartButton.textContent = 'Added!';
+        addToCartButton.disabled = true;
+        
+        setTimeout(() => {
+          addToCartButton.textContent = 'Add to Cart';
+          addToCartButton.disabled = false;
+          localStorage.removeItem('itemAddedTimestamp');
+        }, 5000 - (Date.now() - parseInt(itemAddedTimestamp)));
+      }
     }
   }
 
-  // Add this line at the end of the main IIFE (Immediately Invoked Function Expression)
+  // Make sure this line is at the end of your main IIFE
   document.addEventListener('DOMContentLoaded', updateAddToCartButton);
 })();


### PR DESCRIPTION
1. In addToCart, instead of setting a boolean flag, we now set a timestamp when an item is successfully added to the cart. In updateAddToCartButton, we check if this timestamp exists and if it's less than 5 seconds old. If so, we show the "Added!" message. We use setTimeout to revert the button back to its original state after the remaining time (up to 5 seconds).
4. We remove the timestamp from localStorage after reverting the button state. This approach ensures that the "Added!" message will appear for up to 5 seconds after the page refreshes, even if there's a slight delay in the refresh. It's a more robust and simpler solution than using a boolean flag.