### PR TITLE
These changes will:

### DIFF
--- a/public/shopify-widget.js
+++ b/public/shopify-widget.js
@@ -385,13 +385,11 @@ console.log('Shopify try-on widget script started');
     indicator.style.borderRadius = '6px';
     indicator.style.zIndex = '9998';
     indicator.style.display = 'none';
-    indicator.style.alignItems = 'center';
-    indicator.style.justifyContent = 'center'; // Changed to center
+    indicator.style.alignItems = 'center'; // Keep this for vertical alignment
     indicator.style.boxShadow = '0 1px 3px rgba(0,0,0,0.1)';
     indicator.style.border = '1px solid #e0e0e0';
     indicator.style.maxWidth = '225px';
     indicator.style.fontSize = '13px';
-    indicator.style.textAlign = 'center'; // Added to center text
 
     const spinner = document.createElement('div');
     spinner.className = 'try-on-spinner';
@@ -401,13 +399,14 @@ console.log('Shopify try-on widget script started');
     spinner.style.width = '13px';
     spinner.style.height = '13px';
     spinner.style.animation = 'spin 1s linear infinite';
-    spinner.style.marginRight = '8px';
-    spinner.style.flexShrink = '0'; // Prevent spinner from shrinking
+    spinner.style.margin = '0 8px'; // Equal margin on both sides
+    spinner.style.flexShrink = '0';
     spinner.style.display = 'none'; // Initially hidden
 
     const statusText = document.createElement('span');
-    statusText.style.flex = '1'; // Allow text to take up remaining space
-    statusText.style.textAlign = 'center'; // Center the text
+    statusText.style.flex = '1';
+    statusText.style.textAlign = 'left'; // Left-align the text
+    statusText.style.marginRight = '8px'; // Add margin to the right of the text
 
     indicator.appendChild(spinner);
     indicator.appendChild(statusText);
@@ -433,7 +432,7 @@ console.log('Shopify try-on widget script started');
     
     if (status === 'processing') {
       indicator.style.display = 'flex';
-      spinner.style.display = 'inline-block';
+      spinner.style.display = 'block';
       statusText.textContent = customMessage || 'Try-on in progress...';
     } else {
       indicator.style.display = 'none';


### PR DESCRIPTION
Left-align the text by setting statusText.style.textAlign = 'left'. Add equal margins of 8px on both sides of the spinner with spinner.style.margin = '0 8px'. Add 8px of margin to the right side of the text with statusText.style.marginRight = '8px'. This should create equal spacing between all elements in the status indicator. The spinner will have 8px of space on both sides, and the text will have 8px of space on its right side, creating a balanced look.